### PR TITLE
Pause for flush, fixes race condition.

### DIFF
--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -69,6 +69,7 @@ declare module "redux-persist" {
     purge(keys?: string[]): void;
     rehydrate<State>(incoming: State, options: RehydrateOptions): undefined;
     pause(): void;
+    pauseForFlush(): void;
     resume(): void;
   }
 


### PR DESCRIPTION
Fixes a race condition between `subscribe()` and `flush()` that I've only seen in the Simulator.